### PR TITLE
Introduce ``DJPYLIBMC_RETRY_ON_BROKEN_CONNECTION`` Django setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,10 @@ same values as the Python `zlib <https://docs.python.org/2/library/zlib.html>`_
 module. Please note that pylibmc changed the default from ``1`` (``Z_BEST_SPEED``)
 to ``-1`` (``Z_DEFAULT_COMPRESSION``) in 1.3.0.
 
+Since 0.6.2 connections are long-living and not closed after each request. It could cause unwanted ``ConnectionErrors``
+being raised by libmemcached when connection is broken. ``DJPYLIBMC_RETRY_ON_BROKEN_CONNECTION`` Django setting
+tells dj-pylibmc to make one more attempt when a request to memcached fails with ConnectionError.
+
 
 Configuration with Environment Variables
 ----------------------------------------


### PR DESCRIPTION
It tells dj-pylibmc to make one more attempt when a request to memcached fails with ConnectionError.